### PR TITLE
add name of OU to returned values of each account 

### DIFF
--- a/plugins/inventory/organization.py
+++ b/plugins/inventory/organization.py
@@ -209,8 +209,23 @@ class InventoryModule(AWSInventoryBase):
         if not accounts:
             return
         for account in accounts.get("Accounts") or []:
+            ou_info = self._get_account_ou(account_id=account.get("Id"))
+            account['OU'] = ou_info
             self._expand_tags(account)
             resource["Accounts"].append(account)
+
+    def _get_account_ou(self, account_id):
+        try:
+            paginator = self._orgs_client.get_paginator('list_parents')
+            for response in paginator.paginate(ChildId=account_id):
+                for parent in response['Parents']:
+                    if parent['Type'] == 'ORGANIZATIONAL_UNIT':
+                        ou_details = self._orgs_client.describe_organizational_unit(OrganizationalUnitId=parent['Id'])
+                        return ou_details['OrganizationalUnit']['Name']  # here we can add some more data to be returned
+        except Exception as e:
+            self.fail_aws("Error getting the OU for the account {}: {}".format(account_id, e), exception=e)
+        return None
+
 
     def _expand_ous(self, resource):
         if not resource:

--- a/plugins/inventory/organization.py
+++ b/plugins/inventory/organization.py
@@ -123,7 +123,7 @@ def organizations_error_handler(description):
                     _self.fail_aws(f"Failed to {description}", exception=e)
             except is_boto3_error_code("AWSOrganizationsNotInUseException"):
                 _self.debug("AWS Organizations not in use")
-            except (botocore.exceptions.WaiterError) as e:
+            except botocore.exceptions.WaiterError as e:
                 _self.fail_aws(f"Failed waiting for {description}", exception=e)
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 _self.fail_aws(f"Failed to {description}", exception=e)
@@ -210,22 +210,21 @@ class InventoryModule(AWSInventoryBase):
             return
         for account in accounts.get("Accounts") or []:
             ou_info = self._get_account_ou(account_id=account.get("Id"))
-            account['OU'] = ou_info
+            account["OU"] = ou_info
             self._expand_tags(account)
             resource["Accounts"].append(account)
 
     def _get_account_ou(self, account_id):
         try:
-            paginator = self._orgs_client.get_paginator('list_parents')
+            paginator = self._orgs_client.get_paginator("list_parents")
             for response in paginator.paginate(ChildId=account_id):
-                for parent in response['Parents']:
-                    if parent['Type'] == 'ORGANIZATIONAL_UNIT':
-                        ou_details = self._orgs_client.describe_organizational_unit(OrganizationalUnitId=parent['Id'])
-                        return ou_details['OrganizationalUnit']['Name']  # here we can add some more data to be returned
+                for parent in response["Parents"]:
+                    if parent["Type"] == "ORGANIZATIONAL_UNIT":
+                        ou_details = self._orgs_client.describe_organizational_unit(OrganizationalUnitId=parent["Id"])
+                        return ou_details["OrganizationalUnit"]["Name"]  # here we can add some more data to be returned
         except Exception as e:
             self.fail_aws("Error getting the OU for the account {}: {}".format(account_id, e), exception=e)
         return None
-
 
     def _expand_ous(self, resource):
         if not resource:


### PR DESCRIPTION
SUMMARY
  have added to return values of each account the OU where each account belongs to. This meakes easier to form keyed_groups  based on their OU

ISSUE TYPE
add feature 

COMPONENT NAME
organization

CHANGE EXPLAINED

Return values with new ou parameter
```
      "156518561546": {
          "arn": "arn:aws:organizations::455dsdsd45:account/dsefde/156518561546",
          "email": "email@email.com",
          "id": "45464656",
          "joined_method": "INVITED",
          "joined_timestamp": "2045-08-28T22:31:0894245000+00:00",
          "name": "account_name,
          "ou": "Security",
          "status": "SUSPENDED",
          "tags": {}
      },
```


```
plugin: community.aws.organization
regions:
  - us-east-1
profile: "testing"

keyed_groups:
  - key: ou   
    prefix: ou
    separator: ""

```
Result 
```
    "ouSecurity": {
        "hosts": [
            "156518561546",
            "541864256148"
        ]
    },
```
